### PR TITLE
Get away from master and slave terminology

### DIFF
--- a/stream/py_bus_pirate_lite/I2Chigh.py
+++ b/stream/py_bus_pirate_lite/I2Chigh.py
@@ -50,7 +50,7 @@ class I2Chigh(I2C):
 
 
     def command(self, i2caddr, cmd):
-        """ Writes one byte command to slave """
+        """ Writes one byte command to subordinate """
         self.send_start_bit();
         stat = self.bulk_trans(2, [i2caddr<<1, cmd]);
         self.send_stop_bit();


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.